### PR TITLE
added functionality for extraction graph

### DIFF
--- a/indexify/client.py
+++ b/indexify/client.py
@@ -535,17 +535,25 @@ class IndexifyClient:
         response.raise_for_status()
         return response.json()["results"]
 
-    def upload_file(self, path: str, id=None, labels: dict = {}) -> str:
+    def upload_file(self, path: str, id: str = None, labels: dict = {}, extraction_graph_names = []) -> str:
         """
         Upload a file.
 
         Args:
             - path (str): relative path to the file to be uploaded
+            - id (Optional[str]): ID to be associated with the file (default: None)
             - labels (dict): labels to be associated with the file
+            - extraction_graph_names (List[str]): list of extraction graph names to run the file through (default: [])
         """
         params={}
         if id is not None:
             params['id'] = id
+
+        if extraction_graph_names:
+            params['extraction_graph_names'] = extraction_graph_names
+        else:
+            raise ValueError("Extraction graph names are required")
+
         with open(path, "rb") as f:
             response = self.post(
                 f"namespaces/{self.namespace}/upload_file",

--- a/indexify/extraction_graph.py
+++ b/indexify/extraction_graph.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import List
+
+from indexify.extraction_policy import ExtractionPolicyRequest
+
+
+@dataclass
+class ExtractionGraphRequest:
+  name: str
+  namespace: str
+  policies: List[ExtractionPolicyRequest]

--- a/indexify/extraction_graph.py
+++ b/indexify/extraction_graph.py
@@ -7,5 +7,5 @@ from indexify.extraction_policy import ExtractionPolicyRequest
 @dataclass
 class ExtractionGraphRequest:
   name: str
-  namespace: str
   policies: List[ExtractionPolicyRequest]
+  namespace: str="default"

--- a/indexify/extraction_policy.py
+++ b/indexify/extraction_policy.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, asdict, field
-from typing import Optional
+from typing import Optional, Dict
 
 
 @dataclass
@@ -7,7 +7,7 @@ class ExtractionPolicyRequest:
     extractor: str
     name: str
     content_source: str
-    input_params: dict = field(default=None)
+    input_params: Dict = field(default_factory=dict)
     labels_eq: Optional[str] = None
 
 @dataclass

--- a/indexify/extraction_policy.py
+++ b/indexify/extraction_policy.py
@@ -1,6 +1,14 @@
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from typing import Optional
 
+
+@dataclass
+class ExtractionPolicyRequest:
+    extractor: str
+    name: str
+    content_source: str
+    input_params: dict = field(default=None)
+    labels_eq: Optional[str] = None
 
 @dataclass
 class ExtractionPolicy:
@@ -8,6 +16,7 @@ class ExtractionPolicy:
     name: str
     content_source: str
     input_params: dict
+    graph_name: str
     id: Optional[str] = None
     labels_eq: Optional[str] = None
 

--- a/indexify/utils.py
+++ b/indexify/utils.py
@@ -1,7 +1,13 @@
 from enum import Enum
-
+from dataclasses import is_dataclass, asdict
 
 def json_set_default(obj):
     if isinstance(obj, set):
         return list(obj)
-    raise TypeError
+    elif isinstance(obj, Enum):
+        return obj.value
+    elif is_dataclass(obj):
+        return asdict(obj)
+    elif obj is None:
+        return None
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")


### PR DESCRIPTION
## This PR

* adds support for using extraction graphs on the client
* indexes will now use extraction graph name for additional scoping within the same namespace

Example

```
from indexify import IndexifyClient
from indexify.extraction_graph import ExtractionGraphRequest
from indexify.extraction_policy import ExtractionPolicyRequest

client = IndexifyClient()

extraction_graph_name = "extraction_graph"
extraction_policy = ExtractionPolicyRequest(extractor="tensorlake/minilm-l6", name="wiki-embedding", content_source=extraction_graph_name)
extraction_graph = ExtractionGraphRequest(name=extraction_graph_name, namespace="default", policies=[extraction_policy])
client.add_extraction_graph(extraction_graph=extraction_graph)
client.add_documents("Some text here", extraction_graph_names=[extraction_graph_name])
```

```
import os
from indexify_langchain import IndexifyRetriever
from indexify import IndexifyClient
from langchain_core.output_parsers import StrOutputParser
from langchain_core.prompts import ChatPromptTemplate
from langchain_core.runnables import RunnablePassthrough
from langchain_openai import ChatOpenAI

config_file_path = os.path.abspath("config.yaml")
client = IndexifyClient(config_path=config_file_path)
# params = {"name": "wiki-embedding.embedding", "top_k": 20}
params = { "name": "extraction_graph.wiki-embedding.embedding", "top_k": 20 }
retriever = IndexifyRetriever(client=client, params=params)
template = """Answer the question based only on the following context:
{context}

Question: {question}
"""

print("Done creating the variables")

prompt = ChatPromptTemplate.from_template(template)

model = ChatOpenAI()

chain = (
    {"context": retriever, "question": RunnablePassthrough()}
    | prompt
    | model
    | StrOutputParser()
)
result = chain.invoke("Your query here")
print(result)
```