### PR TITLE
Local cache, Hide Local Runner

### DIFF
--- a/examples/pdf_workflow/workflow.py
+++ b/examples/pdf_workflow/workflow.py
@@ -147,6 +147,8 @@ if __name__ == "__main__":
 
     runner = LocalRunner()
 
+    runner.clear_cache(extract_tables)
+
     url = "https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf"
     runner.run(g, wf_input=url)
 

--- a/examples/pdf_workflow/workflow.py
+++ b/examples/pdf_workflow/workflow.py
@@ -9,13 +9,11 @@ from indexify.extractor_sdk.data import BaseData, PDFFile
 from sentence_transformers import SentenceTransformer
 
 from indexify.graph import Graph
-from indexify.local_runner import LocalRunner
 from tt_module import get_tables
 import pymupdf
 import fitz
 
 from pydantic import BaseModel
-
 
 
 @extractor(description="Download pdf")
@@ -134,7 +132,7 @@ class EmbeddingExtractor(Extractor):
 
 
 if __name__ == "__main__":
-    g = Graph("Extract pages, tables, images from pdf", input=str, start_node=download_pdf)
+    g = Graph("Extract pages, tables, images from pdf", input=str, start_node=download_pdf, run_local=True)
 
     g.add_edge(download_pdf, extract_page_text)
     g.add_edge(download_pdf, extract_images)
@@ -145,22 +143,22 @@ if __name__ == "__main__":
 
     g.add_param(make_chunks, {"chunk_size": 2000})
 
-    runner = LocalRunner()
-
-    runner.clear_cache(extract_tables)
+    # Clear caches if required
+    # g.clear_cache_for_node(extract_tables)
+    # g.clear_cache_for_all_nodes()
 
     url = "https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf"
-    runner.run(g, wf_input=url)
+    g.run(wf_input=url, local=True)
 
-    print(f"number of pages {len(runner.get_result(extract_page_text))}")
-    print(f"number of images {len(runner.get_result(extract_images))}")
-    print(f"number of tables {len(runner.get_result(extract_tables))}")
-    print(f"number of embeddings {len(runner.get_result(EmbeddingExtractor))}")
+    print(f"number of pages {len(g.get_result(extract_page_text))}")
+    print(f"number of images {len(g.get_result(extract_images))}")
+    print(f"number of tables {len(g.get_result(extract_tables))}")
+    print(f"number of embeddings {len(g.get_result(EmbeddingExtractor))}")
 
     print('\n---- Text output')
-    print(runner.get_result(extract_page_text)[3])
+    print(g.get_result(extract_page_text)[3])
     print('---- /Text output\n')
 
     print('\n---- Embedding output')
-    print(runner.get_result(EmbeddingExtractor)[3])
+    print(g.get_result(EmbeddingExtractor)[3])
     print('---- /Embedding output\n')

--- a/indexify/run_graph.py
+++ b/indexify/run_graph.py
@@ -1,0 +1,122 @@
+import json
+
+from .extractor_sdk import Content, extractor, Extractor
+
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Type, Union
+from pydantic import BaseModel
+
+import itertools
+
+from .runner import Runner
+
+@extractor(description="id function")
+def _id(content: Content) -> List[Content]:
+    return [content]
+
+
+class RunGraph:
+    def __init__(self, name: str, input: Type[BaseModel], start_node: extractor, runner: Runner):
+        # TODO check for cycles
+        self.name = name
+
+        self.nodes: Dict[str, Union[extractor, Extractor]] = {}
+        self.params: Dict[str, Any] = {}
+
+        self.edges: Dict[str, List[(str, str)]] = defaultdict(list)
+
+        self.nodes["start"] = _id
+        self.nodes["end"] = _id
+
+        self._topo_counter = defaultdict(int)
+
+        self._start_node = None
+        self._input = input
+
+        self.runner = runner
+
+    def _node(self, extractor: Union[extractor, Extractor], params: Any = None) -> 'RunGraph':
+        name = extractor.name
+
+        # if you've already inserted a node just ignore the new insertion.
+        if name in self.nodes:
+            return
+
+        self.nodes[name] = extractor
+        self.params[name] = extractor.__dict__.get("params", None)
+
+        # assign each node a rank of 1 to init the graph
+        self._topo_counter[name] = 1
+
+        return self
+
+    def add_edge(
+        self,
+        from_node: extractor,
+        to_node: extractor,
+        prefilter_predicates: Optional[str] = None,
+    ) -> 'RunGraph':
+
+        self._node(from_node)
+        self._node(to_node)
+
+        from_node_name = from_node.name
+        to_node_name = to_node.name
+
+        self.edges[from_node_name].append((to_node_name, prefilter_predicates))
+
+        self._topo_counter[to_node_name] += 1
+
+        return self
+
+    """
+    Connect nodes as a fan out from one `from_node` to multiple `to_nodes` and respective `prefilter_predicates`.
+    Note: The user has to match the sizes of the lists to make sure they line up otherwise a None is used as a default.
+    """
+
+    def steps(
+        self,
+        from_node: extractor,
+        to_nodes: List[extractor],
+        prefilter_predicates: List[str] = [],
+    ) -> 'RunGraph':
+        print(f"{to_nodes}, {prefilter_predicates}, {prefilter_predicates}")
+        for t_n, p in itertools.zip_longest(
+            to_nodes, prefilter_predicates, fillvalue=None
+        ):
+            self.step(from_node=from_node, to_node=t_n, prefilter_predicates=p)
+
+        return self
+
+    def add_param(self, node: extractor, params: Dict[str, Any]):
+        try:
+            # check if the params can be serialized since the server needs this
+            json.dumps(params)
+        except Exception:
+            raise Exception(f"For node {node.name}, cannot serialize params as json.")
+
+        self.params[node.name] = params
+
+    def run(self, wf_input, local):
+        self._assign_start_node()
+        # self.runner = LocalRunner()
+        self.runner.run(self, wf_input=wf_input)
+        pass
+
+    def clear_cache_for_node(self, node: Union[extractor, Extractor]):
+        if node.name not in self.nodes.keys():
+            raise Exception(f"Node with name {node.name} not found in graph")
+
+        self.runner.deleted_from_memo(node.name)
+
+    def clear_cache_for_all_nodes(self):
+        for node_name in self.nodes:
+            self.runner.deleted_from_memo(node_name=node_name)
+
+    def get_result(self, node: Union[extractor, Extractor]) -> Any:
+        return self.runner.results[node.name]
+
+    def _assign_start_node(self):
+        # this method should be called before a graph can be run
+        nodes = sorted(self._topo_counter.items(), key=lambda x: x[1])
+        self._start_node = nodes[0][0]

--- a/indexify/runner.py
+++ b/indexify/runner.py
@@ -1,0 +1,22 @@
+from abc import ABC
+
+from indexify.extractor_sdk.data import BaseData
+from indexify.extractor_sdk.extractor import extractor, Extractor
+
+from typing import Any, Union
+
+class Runner(ABC):
+    def run(self, g, wf_input: BaseData):
+        raise NotImplementedError()
+
+    def get_result(self, node: Union[extractor, Extractor]) -> Any:
+        raise NotImplementedError()
+
+    def deleted_from_memo(self, node_name):
+        raise NotImplementedError()
+
+    def get_from_memo(self, node_name, input_hash):
+        raise NotImplementedError()
+
+    def put_into_memo(self, node_name, input_hash, output):
+        raise NotImplementedError()


### PR DESCRIPTION
Add Cache for local runner to memoize function calls. The user is responsible for deleting node caches they don't want. Caches are turned on by default.

Also move local runner to an interface and expose it only through the graph using `local=True` (see workflow example).